### PR TITLE
Remove X close icon from navigation bar

### DIFF
--- a/src/components/organisms/the-navigation-bar/the-navigation-bar.tsx
+++ b/src/components/organisms/the-navigation-bar/the-navigation-bar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Menu, X } from 'react-feather';
+import { Menu } from 'react-feather';
 import { AnimatePresence, motion } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -221,12 +221,7 @@ export const TheNavigationBar: React.FC<TheNavigationBarProps> = ({
                         className="p-2"
                         onClick={() => setIsMenuOpen(!isMenuOpen)}
                     >
-                        <motion.div
-                            animate={{ rotate: isMenuOpen ? 90 : 0 }}
-                            transition={{ duration: 0.2, ease: 'easeOut' }}
-                        >
-                            {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
-                        </motion.div>
+                        <Menu size={24} />
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- simplify navigation bar mobile toggle by dropping the X icon and always showing the menu icon

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Code style issues found in 45 files. Run Prettier with --write to fix.)*


------
https://chatgpt.com/codex/tasks/task_e_68a85d86293c833082b8388007dae2ce