### PR TITLE
feat: add Clawssify experiment

### DIFF
--- a/src/infrastructure/repositories/experiments.repository.ts
+++ b/src/infrastructure/repositories/experiments.repository.ts
@@ -15,6 +15,46 @@ const experiments: Experiment[] = [
     components: [
       {
         architectures: [],
+        description: "Core AI knowledge engine with content processing pipeline.",
+        name: "Core",
+        sourceUrl: new URL(`${REPOSITORY_BASE_URL}clawssify`),
+        status: ExperimentStatus.Building,
+      },
+      {
+        architectures: [],
+        description: "Landing page and product website.",
+        name: "Web Landing",
+        sourceUrl: new URL(`${REPOSITORY_BASE_URL}clawssify-web-landing`),
+        status: ExperimentStatus.Building,
+      },
+      {
+        architectures: [],
+        description: "Internal knowledge base and documentation.",
+        isPrivate: true,
+        name: "Wiki",
+        sourceUrl: new URL(`${REPOSITORY_BASE_URL}clawssify-wiki`),
+        status: ExperimentStatus.Building,
+      },
+    ],
+    context: ExperimentContext.Personal,
+    description:
+      "AI-powered knowledge management that turns shared links and notes into a structured, searchable wiki.",
+    tagline: "Claw. Classify. Clarify.",
+    longDescription:
+      "Stop losing track of what you read. Share URLs, tweets, or notes, and Clawssify reads each source, weaves it into topic-organized wiki pages with footnotes, and delivers a daily digest of what changed. Open source, self-hosted, and markdown-based.",
+    name: "Clawssify",
+    slug: "clawssify",
+    status: ExperimentStatus.Building,
+    storeLinks: {
+      web: "https://clawssify.com",
+    },
+    year: 2026,
+  },
+  {
+    category: ExperimentCategory.App,
+    components: [
+      {
+        architectures: [],
         description: "Open protocol specification for AI agent labor markets.",
         name: "HIRE Protocol",
         sourceUrl: new URL("https://github.com/clawrr/hire"),


### PR DESCRIPTION
## Summary

Add Clawssify, an AI-powered knowledge management system, as a new experiment to the website with three components: Core engine, Web Landing page, and private Wiki documentation.

## Test plan

- Navigate to `/experiments` and verify Clawssify appears in the Applications section
- Click on Clawssify to view the detail page at `/experiments/clawssify`
- Verify all three components are listed with proper links and status badges
- Confirm the website link points to https://clawssify.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)