### PR TITLE
fix: add Makefile for CI pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: test lint build dev clean
+
+test:
+	pnpm install --frozen-lockfile
+	pnpm test run
+
+lint:
+	pnpm install --frozen-lockfile
+	pnpm lint
+
+build:
+	pnpm install --frozen-lockfile
+	pnpm build
+
+dev:
+	pnpm dev
+
+clean:
+	pnpm clean


### PR DESCRIPTION
## Summary

The CI workflow calls `make test` and `make lint` but no Makefile existed, causing all builds to fail. Adds a Makefile that wires up to the existing pnpm scripts.

## Test plan

- Verify CI pipeline passes with `make test` and `make lint` targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)